### PR TITLE
Implement a create method

### DIFF
--- a/mongo_thingy/__init__.py
+++ b/mongo_thingy/__init__.py
@@ -134,6 +134,10 @@ class Thingy(DatabaseThingy):
         else:
             self._id = value
 
+    def create(self):
+        self.get_collection().insert(self.__dict__)
+        return self
+
     def save(self):
         data = self.__dict__
         if self.id:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 from bson import ObjectId
-from pymongo import MongoClient
+from pymongo import errors, MongoClient
 
 from mongo_thingy import Thingy, connect, create_indexes, disconnect, registry
 
@@ -231,6 +231,18 @@ def test_thingy_save(TestThingy, collection):
     assert isinstance(thingy, TestThingy)
     assert thingy.bar == "qux"
     assert thingy._id == "bar"
+
+
+def test_thingy_create(TestThingy, collection):
+    thingy = TestThingy(bar="baz")
+    assert TestThingy.count() == 0
+    thingy.create()
+    assert TestThingy.count() == 1
+    assert isinstance(thingy._id, ObjectId)
+
+    with pytest.raises(errors.DuplicateKeyError):
+        thingy = TestThingy(_id=thingy._id, bar="qux").create()
+    assert TestThingy.count() == 1
 
 
 def test_thingy_delete(TestThingy, collection):


### PR DESCRIPTION
A `create` method would be fine when you want to be sure the document will be inserted and not upserted as with the `save` method.